### PR TITLE
Add basic CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,16 +40,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
   
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
   test:
     name: Test
@@ -67,6 +61,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
       
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test


### PR DESCRIPTION
Resolves #11.

In general it's probably good to get this in place first thing on all projects so we can easily build it up as projects grow.