### PR TITLE
Add struct representing run results

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,5 @@
 mod run;
-pub mod state;
+mod state;
 
 use anyhow::{bail, Result};
 use serde::Deserialize;
@@ -12,6 +12,8 @@ use crate::{
     types::{RunInputs, RunSettings},
     ws,
 };
+
+pub use state::Pressure;
 
 /// Represents a Stirling engine running at cyclic steady state
 pub struct Engine<T: Fluid> {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -10,7 +10,7 @@ pub use rhombic_drive::RhombicDrive;
 use serde::Deserialize;
 pub use sinusoidal_drive::SinusoidalDrive;
 
-use crate::{engine::state::Pressure, types::ParasiticPower};
+use crate::{engine::Pressure, types::ParasiticPower};
 
 pub trait WorkingSpaces {
     /// Returns the frequency (Hz) of the engine

--- a/src/ws/sinusoidal_drive.rs
+++ b/src/ws/sinusoidal_drive.rs
@@ -129,7 +129,7 @@ impl From<Config> for SinusoidalDrive {
 mod tests {
     use approx::{assert_relative_eq, relative_eq};
 
-    use crate::engine::state::Pressure;
+    use crate::engine::Pressure;
 
     use super::*;
 


### PR DESCRIPTION
This PR takes a first pass at the `RunResults` struct, and I'm open to any suggestions on property names.

Having two efficiencies is different from what's in MATLAB because we now have more information about the types
of non-thermal parasitics in the components.

Resolves #41 
