### PR TITLE
Outer loop engine state update (part 1)

### DIFF
--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -183,7 +183,6 @@ impl<T: Fluid> State<T> {
     }
 
     /// Return the `chx::State` that corresponds to this `engine::State`
-    #[allow(dead_code)]
     pub fn chx(&self) -> chx::State {
         chx::State {
             hxr: HeatExchanger {
@@ -199,7 +198,6 @@ impl<T: Fluid> State<T> {
     }
 
     /// Return the `regen::State` that corresponds to this `engine::State`
-    #[allow(dead_code)]
     pub fn regen(&self) -> regen::State {
         regen::State {
             hxr: HeatExchanger {
@@ -214,7 +212,6 @@ impl<T: Fluid> State<T> {
     }
 
     /// Return the `hhx::State` that corresponds to this `engine::State`
-    #[allow(dead_code)]
     pub fn hhx(&self) -> hhx::State {
         hhx::State {
             hxr: HeatExchanger {


### PR DESCRIPTION
This PR updates the engine state during the outer loop and checks that approach temperatures are converged.  It does not yet adjust the `regen_imbalance`, which will happen in part 2.